### PR TITLE
Check out an older version of travis-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /home/travis
 RUN /bin/bash -lc "gem install travis -v 1.8.2 --no-doc --no-ri ; \
 gem install bundler ; \
 git clone https://github.com/travis-ci/travis-build.git ~/.travis/travis-build ; \
+git -C ~/.travis/travis-build checkout ec4f888d3757; \
 bundle install --gemfile ~/.travis/travis-build/Gemfile ; \
 mkdir build ; \
 echo \"export TRAVIS_BUILD_APT_PACKAGE_WHITELIST=https://raw.githubusercontent.com/travis-ci/apt-package-whitelist/master/ubuntu-precise\" >> .bashrc ; \


### PR DESCRIPTION
The current master version of travis-build won't build on the quay.io/travisci/travis-python image (and presumably others) due to the fact that a dependency (ruby_dep) does not run on the ruby version on that image.

It is possible newer versions of travis-build will work too, but I haven't tested this.
